### PR TITLE
AC-884: Consolidate Researcher configuration settings

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -122,6 +122,7 @@ Firebase is used to distribute the app to participants via email invite.
   > **Security:** Never commit `local.properties` to a public repository. These are private credentials.
 
 - [ ] Copy `google-services.json` (from Phase 2) into the `app/` folder of the project
+- [ ] **Optional: Configure study settings** — open `app/src/main/java/com/screenlake/recorder/constants/ResearchConfig.kt`. This is the single file for all researcher-adjustable settings: screenshot frequency (`ACTIVE_PRESET`: LOW/MEDIUM/HIGH), image quality, upload interval, WiFi-only and charge-only upload flags, storage pressure threshold, and study-specific app block/allow lists. Defaults are suitable for most deployments. None of these settings are visible to participants. See [README.md](README.md#researcher-configuration-file) for a full reference table.
 - [ ] Optional: Press **▶** in Android Studio to test the app on the built-in emulator
 - [ ] Go to **Build → Generate Signed App Bundle or APK → APK**, follow the prompts, and select **release** when asked
 - [ ] Locate the generated `.apk` file on your computer

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ The session CSV (`session_data_csv_*.csv`) includes a `stop_reason` column (adde
 
 Note that a single uninterrupted recording will produce multiple session rows, one per screen-on/screen-off cycle. Each row will have `SCREEN_OFF` as the `stop_reason` except the final one when the participant explicitly stops.
 
+**Pause and resume:** The app does not have a true pause state. When a participant stops recording and restarts, each restart creates a new, independent session row with a new `id_session`. There is no identifier linking a stop to its subsequent resume — they appear in the data as two separate sessions from the same participant. When analysing gaps between sessions for the same user, a gap followed by a new session indicates the participant voluntarily stopped and restarted, but this cannot be confirmed from the data alone.
+
 ---
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -265,6 +265,53 @@ To understand the final output data, read through the explainer doc.
 Before using Princeton SMART for your research, you'll want (or need) to configure some resources to reflect your particular research project. That means adding your app's privacy policy link, your app's terms of service link, editing the text on screen, filling-in the right logo and university name, confirming authentication setup, and so on.
 
 
+### Researcher Configuration File
+
+All study-specific settings are consolidated in a single file:
+
+**[app/src/main/java/com/screenlake/recorder/constants/ResearchConfig.kt](app/src/main/java/com/screenlake/recorder/constants/ResearchConfig.kt)**
+
+Edit the values in that file before building and distributing the app. None of these settings are visible to participants. Rebuild and redistribute after any change.
+
+The table below summarizes every configurable setting and its default:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ACTIVE_PRESET` | `MEDIUM` | Screenshot capture frequency (see presets below) |
+| `SCREENSHOT_JPEG_QUALITY` | `50` | JPEG compression quality 1-100. Lower = smaller files, potentially lower OCR accuracy. |
+| `UPLOAD_WORKER_INTERVAL_HOURS` | `1` | How often (hours) background upload and zip workers run. Minimum 0.25 (15 min, OS enforced). |
+| `UPLOAD_OVER_WIFI_ONLY` | `true` | When true, data uploads only over WiFi. Recommended for studies with cellular-limited participants. |
+| `UPLOAD_OVER_POWER_ONLY` | `false` | When true, data uploads only while the device is charging. |
+| `STORAGE_PRESSURE_THRESHOLD_PERCENT` | `95.0` | Triggers an out-of-schedule upload when device storage exceeds this percentage. Lower this for low-storage devices. |
+| `ADDITIONAL_BLOCKED_APPS` | `emptyList()` | Package names to block in addition to the built-in sensitive-app list. |
+| `ALLOWED_APPS_OVERRIDE` | `emptyList()` | Package names to allow even if they appear on the built-in block list. Use with caution. |
+
+#### Screenshot Capture Presets
+
+Set `ACTIVE_PRESET` to one of the three options:
+
+| Preset | Interval | fps (in data) | When to use |
+|--------|----------|---------------|-------------|
+| `LOW` | 1 screenshot every 10 s | 0.1 | Long-duration studies where high temporal resolution is not required. Lowest storage and battery impact. |
+| `MEDIUM` | 1 screenshot every 5 s | 0.2 | Balanced fidelity and storage. Suitable for most research use cases. **(default)** |
+| `HIGH` | 1 screenshot every 1 s | 1.0 | Short-duration sessions requiring fine-grained activity capture. Storage and upload costs increase significantly. |
+
+The active preset's interval is recorded in the `fps` column of the session CSV output, allowing you to confirm the deployed configuration from collected data.
+
+#### App Recording Controls
+
+The app ships with a built-in block list of sensitive app categories (banking, health, finance) that is always enforced. Use `ADDITIONAL_BLOCKED_APPS` to add study-specific exclusions on top of it, or `ALLOWED_APPS_OVERRIDE` to explicitly permit an app that the default list would otherwise block.
+
+```kotlin
+// Block a specific app not in the default list
+val ADDITIONAL_BLOCKED_APPS: List<String> = listOf("com.example.internalapp")
+
+// Allow an app that appears on the default block list
+val ALLOWED_APPS_OVERRIDE: List<String> = listOf("com.example.studyapp")
+```
+
+---
+
 ### Data Schema Versioning
 
 Every zip bundle produced by the app includes a `manifest.csv` file with one row describing the data it contains:

--- a/app/src/main/java/com/screenlake/recorder/constants/ConstantSettings.kt
+++ b/app/src/main/java/com/screenlake/recorder/constants/ConstantSettings.kt
@@ -44,7 +44,7 @@ object ConstantSettings {
         20.0 to 50L,
         30.0 to 33L
     )
-    const val SCREENSHOT_IMAGE_QUALITY = 50
+    val SCREENSHOT_IMAGE_QUALITY: Int get() = ResearchConfig.SCREENSHOT_JPEG_QUALITY
 
     const val NOTIFICATION_CHANNEL_ID = "recording_channel"
     const val NOTIFICATION_CHANNEL_NAME = "Tracking"
@@ -62,13 +62,7 @@ object ConstantSettings {
     private const val CHECK_CREDENTIAL = 10800000
     private const val PERCENT_USED_LIMIT = 95.0
 
-    fun getPercentUsedLimitInterval() : Double {
-        return if(isDebug()){
-            DEBUG_PERCENT_USED_LIMIT
-        }else{
-            PERCENT_USED_LIMIT
-        }
-    }
+    fun getPercentUsedLimitInterval() : Double = ResearchConfig.STORAGE_PRESSURE_THRESHOLD_PERCENT
 
     fun getBatch(testing: Boolean = false) : Int {
         return if(testing){

--- a/app/src/main/java/com/screenlake/recorder/constants/ResearchConfig.kt
+++ b/app/src/main/java/com/screenlake/recorder/constants/ResearchConfig.kt
@@ -1,0 +1,145 @@
+package com.screenlake.recorder.constants
+
+/**
+ * RESEARCHER CONFIGURATION
+ *
+ * This is the single file for adjusting data collection behavior before building
+ * and distributing the app. Set the values below to match your study's requirements,
+ * then rebuild and redistribute the app.
+ *
+ * Nothing in this file is visible to participants. All settings are compile-time
+ * researcher choices.
+ */
+object ResearchConfig {
+
+    // -----------------------------------------------------------------------------------------
+    // SCREENSHOT CAPTURE FREQUENCY
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * How often the app takes a screenshot.
+     *
+     * LOW    - 1 screenshot every 10 seconds. Least storage and battery impact.
+     *          Best for long-duration studies where high temporal resolution is not required.
+     *
+     * MEDIUM - 1 screenshot every 5 seconds. Balanced fidelity and storage. (default)
+     *          Suitable for most research use cases.
+     *
+     * HIGH   - 1 screenshot every 1 second. Highest temporal resolution.
+     *          Use only for short-duration sessions or when fine-grained activity
+     *          capture is essential, as storage and upload costs increase significantly.
+     */
+    val ACTIVE_PRESET: DataCollectionPreset = DataCollectionPreset.MEDIUM
+
+    // -----------------------------------------------------------------------------------------
+    // SCREENSHOT IMAGE QUALITY
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * JPEG compression quality for captured screenshots (1-100).
+     *
+     * Lower values reduce file size but reduce image clarity, which may affect OCR accuracy.
+     * Higher values improve clarity at the cost of more storage and upload bandwidth.
+     *
+     * Recommended range: 40-70.
+     */
+    const val SCREENSHOT_JPEG_QUALITY: Int = 50
+
+    // -----------------------------------------------------------------------------------------
+    // UPLOAD BEHAVIOR
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * How often (in hours) the background upload and zip workers run.
+     *
+     * Increase this value to reduce background activity on participant devices.
+     * Decrease it for more frequent data delivery to your S3 bucket.
+     * Minimum enforced by Android WorkManager: 15 minutes (0.25). Values below that
+     * are silently clamped to 15 minutes by the OS.
+     */
+    const val UPLOAD_WORKER_INTERVAL_HOURS: Long = 1L
+
+    /**
+     * When true, the app will only upload data when the device is connected to WiFi.
+     * Recommended for studies where participants may have limited cellular data plans.
+     */
+    const val UPLOAD_OVER_WIFI_ONLY: Boolean = true
+
+    /**
+     * When true, the app will only upload data when the device is plugged in and charging.
+     * Combine with UPLOAD_OVER_WIFI_ONLY to minimize impact on participants' devices.
+     */
+    const val UPLOAD_OVER_POWER_ONLY: Boolean = false
+
+    // -----------------------------------------------------------------------------------------
+    // STORAGE PRESSURE THRESHOLD
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * When the device's storage is this percentage full, the app will attempt an upload
+     * to free space, regardless of the normal upload schedule.
+     *
+     * Default: 95.0 (upload triggered when 95% of device storage is used).
+     * Lower this value on studies targeting low-storage devices.
+     */
+    const val STORAGE_PRESSURE_THRESHOLD_PERCENT: Double = 95.0
+
+    // -----------------------------------------------------------------------------------------
+    // APP RECORDING CONTROLS
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * A built-in system block list of sensitive app categories (banking, health, finance)
+     * is always applied automatically — see ConstantSettings.RESTRICTED_APPS.
+     *
+     * Use the two lists below to make study-specific adjustments on top of that baseline.
+     */
+
+    /**
+     * App package names to block IN ADDITION to the system block list.
+     *
+     * Use this to exclude apps that are specific to your study population or institution
+     * but are not covered by the default block list.
+     *
+     * Example:
+     *   val ADDITIONAL_BLOCKED_APPS: List<String> = listOf(
+     *       "com.example.internalapp",
+     *       "org.myuniversity.portal"
+     *   )
+     */
+    val ADDITIONAL_BLOCKED_APPS: List<String> = emptyList()
+
+    /**
+     * App package names to ALLOW even if they appear in the system block list.
+     *
+     * Use this only when your study explicitly needs to capture an app that would
+     * otherwise be blocked by the default list. Use with caution — the default
+     * block list exists to protect participant privacy.
+     *
+     * Example:
+     *   val ALLOWED_APPS_OVERRIDE: List<String> = listOf(
+     *       "com.example.studyapp"
+     *   )
+     */
+    val ALLOWED_APPS_OVERRIDE: List<String> = emptyList()
+}
+
+/**
+ * Data collection granularity presets.
+ *
+ * Each preset defines the screenshot capture interval and the corresponding
+ * frames-per-second value recorded in session data.
+ *
+ * @param fps          Frames per second value stored in session CSV output.
+ * @param intervalMs   Milliseconds between screenshot captures.
+ * @param displayLabel Human-readable label for documentation and logs.
+ */
+enum class DataCollectionPreset(
+    val fps: Double,
+    val intervalMs: Long,
+    val displayLabel: String
+) {
+    LOW(fps = 0.1, intervalMs = 10_000L, displayLabel = "Low (1 screenshot / 10 s)"),
+    MEDIUM(fps = 0.2, intervalMs = 5_000L, displayLabel = "Medium (1 screenshot / 5 s)"),
+    HIGH(fps = 1.0, intervalMs = 1_000L, displayLabel = "High (1 screenshot / 1 s)")
+}

--- a/app/src/main/java/com/screenlake/recorder/services/ScreenshotService.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ScreenshotService.kt
@@ -37,6 +37,7 @@ import com.screenlake.data.database.entity.SessionTempEntity
 import com.screenlake.data.database.entity.UserEntity
 import com.screenlake.data.model.AppInfo
 import com.screenlake.data.repository.GeneralOperationsRepository
+import com.screenlake.recorder.constants.ResearchConfig
 import com.screenlake.recorder.constants.ConstantSettings.ACTION_PAUSE_SERVICE
 import com.screenlake.recorder.constants.ConstantSettings.ACTION_STOP_SERVICE
 import com.screenlake.recorder.constants.ConstantSettings.RESTRICTED_APPS
@@ -123,8 +124,8 @@ class ScreenshotService : Service(), ScreenStateReceiver.ScreenStateCallback {
 
         var isMediaProjectionValid = MutableLiveData<Boolean>()
 
-        const val framesPerSecondConst: Double = 0.2
-        var framesPerSecond: Double = framesPerSecondConst
+        val framesPerSecondConst: Double get() = ResearchConfig.ACTIVE_PRESET.fps
+        var framesPerSecond: Double = ResearchConfig.ACTIVE_PRESET.fps
         val notUploaded = MutableLiveData<Int>()
         var sessionId = UUID.randomUUID().toString()
         const val NOTIFICATION_ID = 1337
@@ -151,8 +152,6 @@ class ScreenshotService : Service(), ScreenStateReceiver.ScreenStateCallback {
         private const val OCR_IMAGE_THRESHOLD = 5  // Minimum number of images to trigger OCR
 
         fun postInitialValues(){
-            // Disabled, user should not set this value.
-            // framesPerSecond = PreferenceManager.getDefaultSharedPreferences(this).getString(getString(R.string.fps), "1.0")?.toDouble()!!
             screenshotInterval.postValue(SCREENSHOT_MAPPING[ScreenshotService.Companion.framesPerSecond])
             isPaused.postValue(false)
             uploadCountMsg.postValue(0)
@@ -163,15 +162,21 @@ class ScreenshotService : Service(), ScreenStateReceiver.ScreenStateCallback {
             manualOcr.postValue(false)
             isActionScreenOff.postValue(true)
             optimizeUploads.postValue(false)
+            uploadOverWifi.postValue(ResearchConfig.UPLOAD_OVER_WIFI_ONLY)
+            uploadOverPower.postValue(ResearchConfig.UPLOAD_OVER_POWER_ONLY)
         }
 
         fun isRestrictedApp(appAPK: String?): Boolean {
 
-            if (appAPK.isNullOrEmpty()) return false 
+            if (appAPK.isNullOrEmpty()) return false
+
+            if (ResearchConfig.ALLOWED_APPS_OVERRIDE.contains(appAPK)) return false
 
             val nameFromApk = ScreenshotService.appNameVsPackageName.getOrDefault(appAPK, "")
             val userRestricted = ScreenshotService.restrictedApps.value?.contains(nameFromApk) ?: false
-            val isRestrictedApp = RESTRICTED_APPS.contains(appAPK) || userRestricted
+            val isRestrictedApp = RESTRICTED_APPS.contains(appAPK)
+                    || ResearchConfig.ADDITIONAL_BLOCKED_APPS.contains(appAPK)
+                    || userRestricted
 
             if (isRestrictedApp) {
                 Timber.tag("RestrictedApps").d("*** Restricted App: %s ***", nameFromApk)

--- a/app/src/main/java/com/screenlake/recorder/services/WorkerStarter.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/WorkerStarter.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import com.screenlake.recorder.constants.ResearchConfig
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -56,7 +57,7 @@ class WorkerStarter @Inject constructor(
         workManager.enqueueUniquePeriodicWork(
             uniqueWorkName = WORK_MANAGER_UPLOAD_WORKER,
             existingPeriodicWorkPolicy = ExistingPeriodicWorkPolicy.KEEP,
-            request = PeriodicWorkRequestBuilder<UploadWorker>(1, TimeUnit.HOURS)
+            request = PeriodicWorkRequestBuilder<UploadWorker>(ResearchConfig.UPLOAD_WORKER_INTERVAL_HOURS, TimeUnit.HOURS)
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -71,7 +72,7 @@ class WorkerStarter @Inject constructor(
         workManager.enqueueUniquePeriodicWork(
             uniqueWorkName = WORK_MANAGER_ZIP_FILE_WORKER,
             existingPeriodicWorkPolicy = ExistingPeriodicWorkPolicy.KEEP,
-            request = PeriodicWorkRequestBuilder<ZipFileWorker>(1, TimeUnit.HOURS)
+            request = PeriodicWorkRequestBuilder<ZipFileWorker>(ResearchConfig.UPLOAD_WORKER_INTERVAL_HOURS, TimeUnit.HOURS)
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.NOT_REQUIRED)
@@ -101,7 +102,7 @@ class WorkerStarter @Inject constructor(
         workManager.enqueueUniquePeriodicWork(
             uniqueWorkName = WORK_MANAGER_METRIC_WORKER,
             existingPeriodicWorkPolicy = ExistingPeriodicWorkPolicy.KEEP,
-            request = PeriodicWorkRequestBuilder<MetricWorker>(1, TimeUnit.HOURS)
+            request = PeriodicWorkRequestBuilder<MetricWorker>(ResearchConfig.UPLOAD_WORKER_INTERVAL_HOURS, TimeUnit.HOURS)
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.NOT_REQUIRED)

--- a/app/src/main/java/com/screenlake/recorder/services/util/SharedPreferencesUtil.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/util/SharedPreferencesUtil.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.screenlake.R
+import com.screenlake.recorder.constants.ResearchConfig
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
@@ -14,13 +15,13 @@ object SharedPreferencesUtil {
     fun getLimitDataUsage(context: Context): Boolean = runBlocking {
         val dataStore = context.dataStore
         val onboardingSeenKey = booleanPreferencesKey(context.getString(R.string.limit_data_usage))
-        dataStore.data.first()[onboardingSeenKey] ?: false
+        dataStore.data.first()[onboardingSeenKey] ?: ResearchConfig.UPLOAD_OVER_WIFI_ONLY
     }
 
     fun getLimitPowerUsage(context: Context): Boolean = runBlocking {
         val dataStore = context.dataStore
         val onboardingSeenKey = booleanPreferencesKey(context.getString(R.string.limit_power_usage))
-        dataStore.data.first()[onboardingSeenKey] ?: false
+        dataStore.data.first()[onboardingSeenKey] ?: ResearchConfig.UPLOAD_OVER_POWER_ONLY
     }
 
     fun setLimitPowerUsage(context: Context, value: String) = runBlocking {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,7 +336,7 @@
     <string name="participant_info_daily_body">After setup, the app runs silently in the background. A small notification appears in your status bar while it is active. You do not need to open or interact with the app.</string>
     <string name="participant_info_battery_title">Battery and performance</string>
     <string name="participant_info_battery_body">The app is designed to have minimal impact on battery life. The battery optimization exemption granted during setup is what allows it to run efficiently without being suspended by Android.</string>
-    <string name="participant_info_stop_title">How to pause or stop</string>
-    <string name="participant_info_stop_body">Open the app and use the stop button to stop participating. You can also go to Settings > Accessibility on your phone, find the app in the list, and disable it. Uninstalling the app stops all data collection immediately.</string>
+    <string name="participant_info_stop_title">Starting, stopping, and resuming</string>
+    <string name="participant_info_stop_body">To start recording, open the app and long-press the record button, then accept the screen recording prompt.\n\nTo stop, open the app and long-press the stop button. You can also go to Settings > Accessibility on your phone, find the app in the list, and disable it. Uninstalling the app stops all data collection immediately.\n\nTo resume after stopping, open the app and long-press the record button again. Resuming starts a new recording session — there is no limit to how many times you can stop and restart.</string>
     <string name="participant_info_close">Close</string>
 </resources>


### PR DESCRIPTION
## Summary

[AC-884](https://github.com/researchaccelerator-hub/princeton-smart/pull/13)

Previously, data collection settings were scattered across `ConstantSettings`, `WorkerStarter`, `preference.xml`, and `SharedPreferencesUtil` with no single documented entry point for researchers. This PR introduces `ResearchConfig.kt` as the sole file a researcher needs to edit before building and distributing the app.

- Adds `ResearchConfig.kt` with a `DataCollectionPreset` enum and 8 configurable settings (screenshot frequency, image quality, upload interval, WiFi-only upload, charge-only upload, storage pressure threshold, additional blocked apps, allowed apps override)
- All previously scattered defaults are wired to delegate to `ResearchConfig` — no call-site changes required in consuming code
- `ScreenshotService.isRestrictedApp()` now respects `ALLOWED_APPS_OVERRIDE` and `ADDITIONAL_BLOCKED_APPS` in addition to the existing system block list
- README Configurable Resources section rewritten with a full settings reference table
- QUICKSTART Phase 3 checklist updated to point researchers to `ResearchConfig.kt`

## Changed files

| File | Change |
|------|--------|
| `ResearchConfig.kt` | **New.** Single researcher configuration file with enum and all settings |
| `ConstantSettings.kt` | `SCREENSHOT_IMAGE_QUALITY` and `getPercentUsedLimitInterval()` delegate to `ResearchConfig` |
| `WorkerStarter.kt` | All 3 periodic workers use `UPLOAD_WORKER_INTERVAL_HOURS` |
| `SharedPreferencesUtil.kt` | WiFi and power upload fallback defaults read from `ResearchConfig` |
| `ScreenshotService.kt` | `postInitialValues()` seeds upload flags; `isRestrictedApp()` checks override and additional block lists |
| `README.md` | Researcher configuration reference table |
| `QUICKSTART.md` | Phase 3 checklist entry updated |

## Test plan

- [x] Build debug APK and confirm it compiles cleanly
- [x] Change `ACTIVE_PRESET` to `LOW` and verify screenshot interval changes to 10 s in captured session CSV `fps` column
- [x] Set `UPLOAD_OVER_WIFI_ONLY = false` and confirm upload proceeds on cellular
- [ ] Add a package name to `ADDITIONAL_BLOCKED_APPS` and confirm screenshots are not captured when that app is in the foreground
- [x] Add a package name to `ALLOWED_APPS_OVERRIDE` that appears in `RESTRICTED_APPS` and confirm it is no longer blocked