### PR TITLE
AC-1042: Split zip output into separate CSV and image zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ gradle-app.setting
 /claude-docs/
 /CLAUDE.md
 /.claude
+/docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ gradle-app.setting
 /CLAUDE.md
 /.claude
 /docs/superpowers/
+/.superpowers/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ android {
         }
 
         debug {
+            applicationIdSuffix = ".debug"
             isMinifyEnabled = false
             isDebuggable = true
             proguardFiles(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.screenlake"
         minSdk = 28
         targetSdk = 35
-        versionCode = 50
-        versionName = "1.42"
+        versionCode = 51
+        versionName = "1.50.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
@@ -144,10 +144,10 @@ class ZipFileWorker @AssistedInject constructor(
 
                     val manifestFile = writeManifestCsv(path, zipFileId)
                     csvFiles.add(manifestFile)
-                    imageFiles.add(manifestFile)
 
                     createCsvZipFile(csvFiles, path, zipFileId)
                     if (imageFiles.isNotEmpty()) {
+                        imageFiles.add(manifestFile)
                         createImageZipFile(imageFiles, path, zipFileId, screenshots.size)
                     }
 
@@ -221,7 +221,7 @@ class ZipFileWorker @AssistedInject constructor(
      * @param screenshots The list of screenshots to associate with accessibility events.
      * @param path The path where the CSV should be saved.
      * @param zipFileId The unique identifier for the zip file.
-     * @param toZip The list of files to be included in the zip.
+     * @param csvFiles The list of CSV files to be included in the zip.
      */
     private suspend fun processAccessibilityEvents(
         screenshots: List<ScreenshotEntity>,
@@ -246,7 +246,8 @@ class ZipFileWorker @AssistedInject constructor(
      * @param screenshots The list of screenshots to process.
      * @param path The path where the CSV should be saved.
      * @param zipFileId The unique identifier for the zip file.
-     * @param toZip The list of files to be included in the zip.
+     * @param csvFiles The list of CSV files to be included in the zip.
+     * @param imageFiles The list of image files to be included in the image zip.
      */
     private fun processScreenshots(
         screenshots: List<ScreenshotEntity>,
@@ -282,7 +283,7 @@ class ZipFileWorker @AssistedInject constructor(
      * @param screenshots The list of screenshots to associate with sessions.
      * @param path The path where the CSV should be saved.
      * @param zipFileId The unique identifier for the zip file.
-     * @param toZip The list of files to be included in the zip.
+     * @param csvFiles The list of CSV files to be included in the zip.
      */
     private suspend fun processSessions(
         screenshots: List<ScreenshotEntity>,
@@ -307,7 +308,7 @@ class ZipFileWorker @AssistedInject constructor(
      * @param screenshots The list of screenshots to associate with app segments.
      * @param path The path where the CSV should be saved.
      * @param zipFileId The unique identifier for the zip file.
-     * @param toZip The list of files to be included in the zip.
+     * @param csvFiles The list of CSV files to be included in the zip.
      */
     private suspend fun processAppSegments(
         screenshots: List<ScreenshotEntity>,

--- a/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
@@ -123,7 +123,8 @@ class ZipFileWorker @AssistedInject constructor(
             // Loop until all screenshots are processed
             while (hasMoreScreenshots) {
                 val zipFileId = UUID.randomUUID() // New UUID for each batch
-                val toZip = mutableListOf<File>()
+                val csvFiles = mutableListOf<File>()
+                val imageFiles = mutableListOf<File>()
 
                 val screenshots = generalOperationsRepository.getPaginateScreenshotsById(0L, lastProcessedId, limit)
 
@@ -136,15 +137,24 @@ class ZipFileWorker @AssistedInject constructor(
 
                     findDuplicates(screenshots, zipFileId)
 
-                    processAccessibilityEvents(screenshots, path, zipFileId, toZip)
-                    processScreenshots(screenshots, path, zipFileId, toZip)
-                    processSessions(screenshots, path, zipFileId, toZip)
-                    processAppSegments(screenshots, path, zipFileId, toZip)
-                    val manifestFile = writeManifestCsv(path, zipFileId)
-                    toZip.add(manifestFile)
+                    processAccessibilityEvents(screenshots, path, zipFileId, csvFiles)
+                    processScreenshots(screenshots, path, zipFileId, csvFiles, imageFiles)
+                    processSessions(screenshots, path, zipFileId, csvFiles)
+                    processAppSegments(screenshots, path, zipFileId, csvFiles)
 
-                    // Create zip file for this batch
-                    createCsvZipFile(toZip, path, zipFileId)
+                    val manifestFile = writeManifestCsv(path, zipFileId)
+                    csvFiles.add(manifestFile)
+                    imageFiles.add(manifestFile)
+
+                    createCsvZipFile(csvFiles, path, zipFileId)
+                    if (imageFiles.isNotEmpty()) {
+                        createImageZipFile(imageFiles, path, zipFileId, screenshots.size)
+                    }
+
+                    // Delete all temp files after both zips are written; distinctBy prevents double-delete of the shared manifest
+                    (csvFiles + imageFiles)
+                        .distinctBy { it.absolutePath }
+                        .forEach { it.withLogging("Zip Worker", "Delete") { file -> file.delete() } }
 
                     // Update lastProcessedId for next batch instead of using offset
                     lastProcessedId = screenshots.lastOrNull()?.id
@@ -217,7 +227,7 @@ class ZipFileWorker @AssistedInject constructor(
         screenshots: List<ScreenshotEntity>,
         path: String,
         zipFileId: UUID,
-        toZip: MutableList<File>
+        csvFiles: MutableList<File>
     ) {
         val accessibilityEvents = generalOperationsRepository.getASEvents()
         if (accessibilityEvents.isNotEmpty()) {
@@ -225,7 +235,7 @@ class ZipFileWorker @AssistedInject constructor(
             val accessibilityEventsCSVs = DataTransformation.createAccessibilityCSVs(modifiedASEvents)
             val accessibilityEventsCSVsFile = "app_accessibility_data_csv_${zipFileId}.csv"
             writeFileOnInternalStorage(accessibilityEventsCSVsFile, accessibilityEventsCSVs, path)
-            toZip.add(File(path, accessibilityEventsCSVsFile))
+            csvFiles.add(File(path, accessibilityEventsCSVsFile))
             generalOperationsRepository.deleteAccessibilityEvents(accessibilityEvents.mapNotNull { it.id })
         }
     }
@@ -242,21 +252,22 @@ class ZipFileWorker @AssistedInject constructor(
         screenshots: List<ScreenshotEntity>,
         path: String,
         zipFileId: UUID,
-        toZip: MutableList<File>
+        csvFiles: MutableList<File>,
+        imageFiles: MutableList<File>
     ) {
         screenshots.forEach { it.zipFileId = "image_zip_${zipFileId}_${screenshots.size}.zip" }
 
         val screenshotCsv = DataTransformation.createScreenshotCsv(screenshots)
         val screenshotCSVFile = "screenshot_data_csv_${zipFileId}.csv"
         writeFileOnInternalStorage(screenshotCSVFile, screenshotCsv, path)
-        toZip.add(File(path, screenshotCSVFile) )
+        csvFiles.add(File(path, screenshotCSVFile))
 
         if (userObj?.uploadImages == true) {
             for (screenshot in screenshots) {
                 if (screenshot.isAppRestricted == false && !screenshot.fileName.isNullOrEmpty()) {
                     val file = File(screenshot.filePath!!)
                     if (file.exists()) {
-                        toZip.add(file)
+                        imageFiles.add(file)
                     }
                 }
             }
@@ -277,7 +288,7 @@ class ZipFileWorker @AssistedInject constructor(
         screenshots: List<ScreenshotEntity>,
         path: String,
         zipFileId: UUID,
-        toZip: MutableList<File>
+        csvFiles: MutableList<File>
     ) {
         val sessionIds = screenshots.mapNotNull { it.sessionId }.distinct()
         val sessions = withContext(Dispatchers.IO) { generalOperationsRepository.getSessionsById(sessionIds) }
@@ -285,7 +296,7 @@ class ZipFileWorker @AssistedInject constructor(
             val sessionCsv = DataTransformation.createSessionJson(sessions)
             val sessionCSVFile = "session_data_csv_${zipFileId}.csv"
             writeFileOnInternalStorage(sessionCSVFile, sessionCsv, path)
-            toZip.add(File(path, sessionCSVFile))
+            csvFiles.add(File(path, sessionCSVFile))
             generalOperationsRepository.deleteSessionsId(sessions.mapNotNull { it.id }.toList())
         }
     }
@@ -302,7 +313,7 @@ class ZipFileWorker @AssistedInject constructor(
         screenshots: List<ScreenshotEntity>,
         path: String,
         zipFileId: UUID,
-        toZip: MutableList<File>
+        csvFiles: MutableList<File>
     ) {
         val uniqueSessions = screenshots.mapNotNull { it.sessionId }.toHashSet().map { it.toString() }
         val appSegments = generalOperationsRepository.getAppSegmentsBySessionId(uniqueSessions)
@@ -310,7 +321,7 @@ class ZipFileWorker @AssistedInject constructor(
             val appSegmentCsv = DataTransformation.createAppSegmentCSV(appSegments)
             val appSegmentCSVFile = "app_segment_data_csv_${zipFileId}.csv"
             writeFileOnInternalStorage(appSegmentCSVFile, appSegmentCsv, path)
-            toZip.add(File(path, appSegmentCSVFile))
+            csvFiles.add(File(path, appSegmentCSVFile))
             generalOperationsRepository.deleteAppSegments(appSegments.map { it.id.toString() })
         }
     }

--- a/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
@@ -140,7 +140,8 @@ class ZipFileWorker @AssistedInject constructor(
                     processScreenshots(screenshots, path, zipFileId, toZip)
                     processSessions(screenshots, path, zipFileId, toZip)
                     processAppSegments(screenshots, path, zipFileId, toZip)
-                    writeManifestCsv(path, zipFileId, toZip)
+                    val manifestFile = writeManifestCsv(path, zipFileId)
+                    toZip.add(manifestFile)
 
                     // Create zip file for this batch
                     createZipFile(toZip, path, zipFileId, screenshots.size, screenshots.mapNotNull { it.id })
@@ -314,7 +315,7 @@ class ZipFileWorker @AssistedInject constructor(
         }
     }
 
-    private fun writeManifestCsv(path: String, zipFileId: UUID, toZip: MutableList<File>) {
+    private fun writeManifestCsv(path: String, zipFileId: UUID): File {
         val nowMs = System.currentTimeMillis()
         val csv = buildString {
             append("\"app_version\",\"schema_version\",\"zip_id\",\"recorded_at_epoch_ms\",\"recorded_at_utc\"\n")
@@ -322,7 +323,7 @@ class ZipFileWorker @AssistedInject constructor(
         }
         val fileName = "manifest_${zipFileId}.csv"
         writeFileOnInternalStorage(fileName, csv, path)
-        toZip.add(File(path, fileName))
+        return File(path, fileName)
     }
 
     /**

--- a/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ZipFileWorker.kt
@@ -144,7 +144,7 @@ class ZipFileWorker @AssistedInject constructor(
                     toZip.add(manifestFile)
 
                     // Create zip file for this batch
-                    createZipFile(toZip, path, zipFileId, screenshots.size, screenshots.mapNotNull { it.id })
+                    createCsvZipFile(toZip, path, zipFileId)
 
                     // Update lastProcessedId for next batch instead of using offset
                     lastProcessedId = screenshots.lastOrNull()?.id
@@ -327,16 +327,15 @@ class ZipFileWorker @AssistedInject constructor(
     }
 
     /**
-     * Creates a zip file from the specified files and updates the database.
+     * Creates a CSV zip file containing CSV data files.
      *
-     * @param toZip The list of files to include in the zip.
+     * @param csvFiles The list of CSV files to include in the zip.
      * @param path The path where the zip should be saved.
      * @param zipFileId The unique identifier for the zip file.
-     * @param screenshotCount The number of screenshots included in the zip.
      */
-    private fun createZipFile(toZip: MutableList<File>, path: String, zipFileId: UUID, screenshotCount: Int, screenshots: List<Int>) {
-        val zipFile = File(path, "image_zip_${zipFileId}_${screenshotCount}.zip")
-        ZipFile().zip(zipFile, toZip)
+    private fun createCsvZipFile(csvFiles: List<File>, path: String, zipFileId: UUID) {
+        val zipFile = File(path, "csv_zip_${zipFileId}.zip")
+        ZipFile().zip(zipFile, csvFiles)
 
         val zipObj = ScreenshotZipEntity().apply {
             this.file = zipFile.toString()
@@ -354,8 +353,38 @@ class ZipFileWorker @AssistedInject constructor(
             exportZipForDebugging(zipFile)
         }
 
-        toZip.forEach { it.withLogging("Zip Worker", "Delete") { file -> file.delete() } }
-        Timber.tag(TAG).d("Zip file created with ${toZip.size} files.")
+        Timber.tag(TAG).d("CSV zip created with ${csvFiles.size} files.")
+    }
+
+    /**
+     * Creates an image zip file containing screenshot image files.
+     *
+     * @param imageFiles The list of image files to include in the zip.
+     * @param path The path where the zip should be saved.
+     * @param zipFileId The unique identifier for the zip file.
+     * @param screenshotCount The number of screenshots included in the zip.
+     */
+    private fun createImageZipFile(imageFiles: List<File>, path: String, zipFileId: UUID, screenshotCount: Int) {
+        val zipFile = File(path, "image_zip_${zipFileId}_${screenshotCount}.zip")
+        ZipFile().zip(zipFile, imageFiles)
+
+        val zipObj = ScreenshotZipEntity().apply {
+            this.file = zipFile.toString()
+            this.localTimeStamp = TimeUtility.getCurrentTimestampDefaultTimezoneString()
+            this.timestamp = TimeUtility.getCurrentTimestampString()
+            this.user = userObj?.email ?: ""
+            this.toDelete = false
+            this.panelId = userObj?.panelId?.toString() ?: ""
+            this.panelName = userObj?.panelName ?: ""
+        }
+
+        generalOperationsRepository.insertScreenshotZip(zipObj)
+
+        if (BuildConfig.DEBUG && BuildConfig.DEBUG_ZIP_EXPORT) {
+            exportZipForDebugging(zipFile)
+        }
+
+        Timber.tag(TAG).d("Image zip created with ${imageFiles.size} files.")
     }
 
     private fun exportZipForDebugging(zipFile: File) {


### PR DESCRIPTION
## Summary

- Replaces the single `image_zip_<id>_<count>.zip` output per batch with two distinct files: `csv_zip_<id>.zip` (all CSV data) and `image_zip_<id>_<count>.zip` (images only), so researchers can access each independently on S3
- Manifest CSV is written once and included in both zips to ensure timestamp consistency
- Image zip is only created when real image files exist (`uploadImages == true` and non-restricted screenshots); both zips register a `ScreenshotZipEntity` row so the existing `UploadWorker` pipeline handles them without changes

## Changes

Only `ZipFileWorker.kt` is modified:
- `writeManifestCsv` refactored to return `File` instead of mutating the file list
- `createZipFile` replaced by `createCsvZipFile` and `createImageZipFile` (file deletion moved to call site)
- All `process*` methods updated from a single `toZip` list to separate `csvFiles` / `imageFiles` lists
- `zipUpScreenshots` rewired to build both lists, write the manifest once, conditionally create the image zip, and clean up via `distinctBy` to avoid double-deleting the shared manifest

## Test plan

- [x] Build passes: `./gradlew :app:compileDebugKotlin`
- [x] Existing instrumented tests pass: `./gradlew :app:connectedDebugAndroidTest`
- [x] Manual: trigger a batch with `DEBUG_ZIP_EXPORT == true` using `test_zip_capture.py`

## Test results

- CSVs and screenshots are in separate zip files. 
<img width="536" height="844" alt="image" src="https://github.com/user-attachments/assets/2393ae6f-3201-4abe-95d5-5a2e887d88ef" />
