### PR TITLE
AC-1043: Fix credential storage race causing tag-zero upload failures on new accounts

### DIFF
--- a/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
+++ b/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
@@ -259,6 +259,10 @@ class GeneralOperationsRepository @Inject constructor(
         return userDao.getUser()
     }
 
+    suspend fun userExists(): Boolean {
+        return userDao.userExists()
+    }
+
     fun incrementCredentialFailureCount(): Int {
         val prefs = context.getSharedPreferences(CREDENTIAL_RECOVERY_PREFS, Context.MODE_PRIVATE)
         val next = prefs.getInt(CREDENTIAL_FAILURE_COUNT_KEY, 0) + 1

--- a/app/src/main/java/com/screenlake/recorder/authentication/EncryptedCredentialsStore.kt
+++ b/app/src/main/java/com/screenlake/recorder/authentication/EncryptedCredentialsStore.kt
@@ -7,14 +7,30 @@ import androidx.security.crypto.MasterKeys
 import com.screenlake.data.model.EmailPasswordData
 import java.lang.ref.WeakReference
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
- * Reads credentials persisted in Android Keystore-backed encrypted shared preferences.
+ * Reads and writes credentials persisted in Android Keystore-backed encrypted shared
+ * preferences.
  *
- * Extracted from [CloudAuthentication] so other consumers (e.g. auth recovery) can read the
- * same stored credentials without duplicating the EncryptedSharedPreferences/MasterKeys setup.
+ * The sole owner of the "encrypted_prefs" file and its backing MasterKey/Tink keyset -- every
+ * reader and writer of stored credentials must go through this class. [CloudAuthentication] and
+ * [AuthRecoveryManager] both read via this singleton; registration writes via this singleton too
+ * (see [storeCredentials]), so there is exactly one file name and one keyset in play.
+ *
+ * The underlying [SharedPreferences] instance is created at most once and cached: the first
+ * ever call to `EncryptedSharedPreferences.create()` on a device also creates the Keystore
+ * master key and Tink keyset, and calling it concurrently from multiple threads on that first
+ * call is known to corrupt the keyset (Tink then fails to parse it back, surfacing as
+ * `InvalidProtocolBufferException: Protocol message contained an invalid tag (zero)`).
+ * Serializing creation behind a lock and reusing the cached instance for every subsequent call
+ * eliminates that race.
  */
+@Singleton
 class EncryptedCredentialsStore @Inject constructor() {
+
+    @Volatile
+    private var cachedPreferences: SharedPreferences? = null
 
     /**
      * Retrieves the encrypted credentials.
@@ -34,23 +50,49 @@ class EncryptedCredentialsStore @Inject constructor() {
     }
 
     /**
-     * Retrieves the encrypted shared preferences.
+     * Persists the given credentials for later retrieval by [getStoredCredentials].
+     *
+     * @param context The context.
+     * @param email The email to store.
+     * @param password The password to store.
+     */
+    fun storeCredentials(context: WeakReference<Context>, email: String, password: String) {
+        getEncryptedSharedPreference(context)?.edit()?.apply {
+            putString("email", email)
+            putString("password", password)
+        }?.apply()
+    }
+
+    /**
+     * Retrieves the encrypted shared preferences, creating (and caching) them on first use.
      *
      * @param context The context.
      * @return The encrypted shared preferences.
      */
     private fun getEncryptedSharedPreference(context: WeakReference<Context>): SharedPreferences? {
-        val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
-        val masterKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
+        cachedPreferences?.let { return it }
 
-        return context.get()?.let {
-            EncryptedSharedPreferences.create(
-                "encrypted_prefs",
+        synchronized(lock) {
+            cachedPreferences?.let { return it }
+
+            val ctx = context.get() ?: return null
+            val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
+            val masterKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
+
+            val prefs = EncryptedSharedPreferences.create(
+                FILE_NAME,
                 masterKeyAlias,
-                it,
+                ctx.applicationContext,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             )
+            cachedPreferences = prefs
+            return prefs
         }
+    }
+
+    companion object {
+        private const val FILE_NAME = "encrypted_prefs"
+        private val lock = Any()
     }
 }

--- a/app/src/main/java/com/screenlake/recorder/services/UploadWorker.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/UploadWorker.kt
@@ -103,6 +103,11 @@ class UploadWorker @AssistedInject constructor(
      * after successful uploads.
      */
     private suspend fun uploadZipFilesAsync() = withContext(Dispatchers.IO) {
+        if (!generalOperationsRepository.userExists()) {
+            Timber.tag(TAG).d("No user registered yet. Skipping this upload run.")
+            return@withContext
+        }
+
         // Fetch the list of zips to upload and the user information
         zipsToUpload = generalOperationsRepository.getZipsToUpload().take(10)?.toMutableList()
         user = generalOperationsRepository.getUser()

--- a/app/src/main/java/com/screenlake/ui/fragments/onboarding/RegisterLoadingFragment.kt
+++ b/app/src/main/java/com/screenlake/ui/fragments/onboarding/RegisterLoadingFragment.kt
@@ -13,14 +13,13 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 import com.screenlake.MainActivity
 import com.screenlake.R
 import com.screenlake.recorder.constants.ConstantSettings
 import com.screenlake.data.database.entity.UserEntity
 import com.screenlake.data.repository.AmplifyRepository
 import com.screenlake.recorder.authentication.CloudAuthentication
+import com.screenlake.recorder.authentication.EncryptedCredentialsStore
 import com.screenlake.recorder.services.util.SharedPreferencesUtil
 import com.screenlake.recorder.utilities.BaseUtility
 import com.screenlake.recorder.viewmodels.UserViewModel
@@ -41,6 +40,9 @@ class RegisterLoadingFragment : Fragment() {
 
     @Inject
     lateinit var cloudAuthentication: CloudAuthentication
+
+    @Inject
+    lateinit var encryptedCredentialsStore: EncryptedCredentialsStore
 
     private val userViewModel: UserViewModel by viewModels()
 
@@ -116,7 +118,9 @@ class RegisterLoadingFragment : Fragment() {
 
         context?.let { SharedPreferencesUtil.setLimitDataUsage(it, true) }
 
-        user.email?.let { createAndEncryptPassword(it, amplifyRepository.password) }
+        user.email?.let {
+            encryptedCredentialsStore.storeCredentials(WeakReference(requireContext()), it, amplifyRepository.password)
+        }
 
         isUserSetupCompleted.postValue(true)
     }
@@ -128,24 +132,6 @@ class RegisterLoadingFragment : Fragment() {
             // Save user locally
             userViewModel.insertUser(user)
         }
-    }
-
-    private fun createAndEncryptPassword(email: String, password: String){
-        val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
-        val masterKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
-
-        val sharedPreferences = EncryptedSharedPreferences.create(
-            "shared_preferences_filename",
-            masterKeyAlias,
-            this.requireContext(),
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-
-        sharedPreferences.edit().apply {
-            putString("email", email)
-            putString("password", password)
-        }.apply()
     }
 
     override fun onCreateView(

--- a/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositoryCredentialFailureTest.kt
+++ b/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositoryCredentialFailureTest.kt
@@ -13,8 +13,12 @@ import com.screenlake.data.database.dao.SessionDao
 import com.screenlake.data.database.dao.UploadDailyDao
 import com.screenlake.data.database.dao.UploadHistoryDao
 import com.screenlake.data.database.dao.UserDao
+import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,8 +26,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class GeneralOperationsRepositoryCredentialFailureTest {
 
+    private lateinit var userDao: UserDao
+
     private fun buildRepository(): GeneralOperationsRepository {
         val context: Context = ApplicationProvider.getApplicationContext()
+        userDao = mockk(relaxed = true)
         return GeneralOperationsRepository(
             context = context,
             logEventDao = mockk(relaxed = true),
@@ -33,7 +40,7 @@ class GeneralOperationsRepositoryCredentialFailureTest {
             sessionDao = mockk<SessionDao>(relaxed = true),
             screenshotDao = mockk<ScreenshotDao>(relaxed = true),
             screenshotZipDao = mockk<ScreenshotZipDao>(relaxed = true),
-            userDao = mockk<UserDao>(relaxed = true),
+            userDao = userDao,
             uploadHistoryDao = mockk<UploadHistoryDao>(relaxed = true),
             uploadDailyDao = mockk<UploadDailyDao>(relaxed = true),
             restrictedAppDao = mockk<RestrictedAppDao>(relaxed = true),
@@ -65,5 +72,17 @@ class GeneralOperationsRepositoryCredentialFailureTest {
         repo.resetCredentialFailureCount()
 
         assertEquals(0, repo.getCredentialFailureCount())
+    }
+
+    @Test
+    fun `userExists delegates to the DAO`() = runTest {
+        val repo = buildRepository()
+        coEvery { userDao.userExists() } returns false
+
+        assertFalse(repo.userExists())
+
+        coEvery { userDao.userExists() } returns true
+
+        assertTrue(repo.userExists())
     }
 }

--- a/app/src/test/java/com/screenlake/recorder/authentication/EncryptedCredentialsStoreTest.kt
+++ b/app/src/test/java/com/screenlake/recorder/authentication/EncryptedCredentialsStoreTest.kt
@@ -1,0 +1,107 @@
+package com.screenlake.recorder.authentication
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.lang.ref.WeakReference
+
+/**
+ * Registration writes credentials via [EncryptedCredentialsStore.storeCredentials];
+ * [CloudAuthentication.autoSignIn] and [AuthRecoveryManager.attemptSilentReauth] read them back
+ * via [EncryptedCredentialsStore.getStoredCredentials]. Both must resolve to the same encrypted
+ * file and the same cached keyset, or credentials silently vanish and every concurrent first
+ * access risks corrupting the underlying Tink keyset (surfacing as
+ * `InvalidProtocolBufferException: Protocol message contained an invalid tag (zero)`). These
+ * tests stub the static AndroidX factory methods so they run as plain JVM unit tests, without
+ * touching the real Android Keystore.
+ */
+class EncryptedCredentialsStoreTest {
+
+    private val fakeBackingMap = mutableMapOf<String, String>()
+    private lateinit var fakePreferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        fakeBackingMap.clear()
+
+        val fakeEditor = mockk<SharedPreferences.Editor>(relaxed = true)
+        every { fakeEditor.putString(any(), any()) } answers {
+            fakeBackingMap[firstArg()] = secondArg()
+            fakeEditor
+        }
+
+        fakePreferences = mockk()
+        every { fakePreferences.getString(any(), any()) } answers {
+            fakeBackingMap[firstArg()] ?: secondArg()
+        }
+        every { fakePreferences.edit() } returns fakeEditor
+
+        mockkStatic(MasterKeys::class)
+        mockkStatic(EncryptedSharedPreferences::class)
+        every { MasterKeys.getOrCreate(any()) } returns "fake-alias"
+        every {
+            EncryptedSharedPreferences.create(any(), any(), any(), any(), any())
+        } returns fakePreferences
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(MasterKeys::class)
+        unmockkStatic(EncryptedSharedPreferences::class)
+    }
+
+    private fun fakeContext(): WeakReference<Context> {
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        return WeakReference(context)
+    }
+
+    @Test
+    fun `credentials stored are the same credentials later retrieved`() {
+        val store = EncryptedCredentialsStore()
+
+        store.storeCredentials(fakeContext(), "participant@example.com", "hunter2")
+        val creds = store.getStoredCredentials(fakeContext())
+
+        assertEquals("participant@example.com", creds.email)
+        assertEquals("hunter2", creds.password)
+    }
+
+    @Test
+    fun `the underlying encrypted preferences file is created only once across multiple callers`() {
+        val store = EncryptedCredentialsStore()
+
+        // Simulates CloudAuthentication.autoSignIn, AuthRecoveryManager.attemptSilentReauth, and
+        // registration's storeCredentials all reaching this store around the same time, each
+        // with their own Context reference.
+        store.getStoredCredentials(fakeContext())
+        store.storeCredentials(fakeContext(), "a@b.com", "pw")
+        store.getStoredCredentials(fakeContext())
+
+        verify(exactly = 1) { EncryptedSharedPreferences.create(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `reads and writes use the same file name`() {
+        val store = EncryptedCredentialsStore()
+        val fileNameSlot = slot<String>()
+        every {
+            EncryptedSharedPreferences.create(capture(fileNameSlot), any(), any(), any(), any())
+        } returns fakePreferences
+
+        store.storeCredentials(fakeContext(), "a@b.com", "pw")
+
+        assertEquals("encrypted_prefs", fileNameSlot.captured)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug reported after 1.50.0 shipped: uploads on a brand-new account created through the app's registration fail immediately with `Protocol message contained an invalid tag (zero)`. Logging out and back in worked around it, which pointed at the credential-storage path used only right after registration.

Two bugs, both in the encrypted credential-storage subsystem:

- **Filename mismatch**: registration wrote stored credentials to `"shared_preferences_filename"`, but `CloudAuthentication.autoSignIn()` / `AuthRecoveryManager.attemptSilentReauth()` read from `"encrypted_prefs"`. Stored credentials were always blank, so `autoSignIn()` silently failed and the account was never actually authenticated after registration.
- **Race condition**: because of the above, the very first upload attempt hit `checkCredentials()` failure and fell into `attemptSilentReauth()`, which calls `EncryptedSharedPreferences.create()` fresh on every access with no caching or synchronization. On a brand-new device this is the first-ever creation of the Android Keystore master key and Tink keyset; racing that creation corrupts it, and Tink's protobuf parser then throws `InvalidProtocolBufferException: Protocol message contained an invalid tag (zero)`.

`EncryptedCredentialsStore` is now the sole owner of the encrypted credentials file (a Hilt singleton, caching the created `SharedPreferences` instance behind a lock so the keyset is created at most once), and registration writes through it via a new `storeCredentials()` method instead of hand-rolling its own differently-named file.

Also fixes a related issue found while verifying this on-device: `UploadWorker`'s periodic run called `UserDao.getUser()` (non-null return type) before a user row exists, which throws `IllegalStateException` and gets logged as `UPLOAD_SERVICE_RUN_FAIL` with a full stack trace, that log entry then gets bundled into the CSV uploaded as research data. `UploadWorker` now checks `userExists()` first and skips cleanly.

## Test plan

- [x] New unit test (`EncryptedCredentialsStoreTest`) proves `EncryptedSharedPreferences.create()` is called at most once across concurrent callers, and that stored/retrieved credentials use the same file name.
- [x] New unit test (`GeneralOperationsRepositoryCredentialFailureTest`) covers the `userExists()` delegate.
- [x] Full unit test suite passes (`./gradlew testDebugUnitTest`).
- [x] Verified on a physical device with app data fully cleared (genuinely first-ever Keystore/keyset creation): registered a brand-new account, confirmed `autoSignIn()` succeeded with real stored credentials, confirmed `encrypted_prefs.xml` is written and read consistently, and confirmed the full OCR -> zip -> upload pipeline (including the AC-1042 split CSV/image zips) completed successfully with no crash, no `CredentialExpiredException`, and no recurrence of the tag-zero error.