### PR TITLE
AC-1044: Document repeated permission prompt behavior

### DIFF
--- a/PARTICIPANT_GUIDE.md
+++ b/PARTICIPANT_GUIDE.md
@@ -76,6 +76,8 @@ Once all three permissions are granted, the app is ready. Tap **Start** to begin
 
 After setup, the app runs silently in the background. You do not need to open or interact with it. A small notification will appear in your status bar to indicate the app is active. You can continue using your phone normally.
 
+Occasionally you may be asked to confirm a permission again, such as screen recording, even though you already granted it before. This is normal behavior built into Android to protect your privacy, not a sign that anything is wrong. Just tap to confirm again and the app will keep running.
+
 ---
 
 ## Battery and performance

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,6 +29,12 @@ Participants receive an email from Firebase with a link to install the app. Afte
 2. Complete a one-time permission-granting flow (usage access, battery optimization, accessibility service) — this requires navigating system settings on their phone, guided by the app
 3. The app then runs passively in the background with no further interaction required
 
+**Note on repeated prompts:** Some participants may occasionally see a permission or screen-recording prompt reappear, even though it was already granted. This is expected Android behavior, not a bug in the app:
+- **Screen recording prompt:** Since Android 14, the OS requires a fresh confirmation any time the recording session is interrupted, for example if it closes the app in the background to save memory or battery.
+- **Accessibility permission:** Because the app is installed directly rather than through the Play Store, Android can periodically re-lock the Accessibility toggle ("Restricted settings"), which requires the participant to unlock it again through a settings menu.
+
+Neither of these can be disabled from within the app. They are Android privacy protections that apply to any app in this situation. Let participants know that an occasional one-tap re-confirmation is normal and does not mean anything is wrong.
+
 ---
 
 ## What do you need before starting?


### PR DESCRIPTION
## Summary
- Documents in QUICKSTART.md why researchers may see participants report repeated permission/screen-recording prompts (Android 14+ single-use MediaProjection consent, and Restricted Settings re-locking Accessibility on sideloaded installs)
- Adds a short reassuring note in PARTICIPANT_GUIDE.md so participants understand an occasional re-confirmation prompt is expected Android behavior, not a bug