### PR TITLE
AC-1221: Move session-active tracking to SharedPreferences

### DIFF
--- a/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
+++ b/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
@@ -280,6 +280,21 @@ class GeneralOperationsRepository @Inject constructor(
         return prefs.getInt(CREDENTIAL_FAILURE_COUNT_KEY, 0)
     }
 
+    fun markSessionActive() {
+        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(SESSION_ACTIVE_KEY, true).apply()
+    }
+
+    fun markSessionInactive() {
+        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(SESSION_ACTIVE_KEY, false).apply()
+    }
+
+    fun isSessionActive(): Boolean {
+        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        return prefs.getBoolean(SESSION_ACTIVE_KEY, false)
+    }
+
     /**
      * Forces a sign-out and clears the local user record after credential recovery has
      * permanently failed (the consecutive-failure notification threshold), so the app routes to
@@ -588,5 +603,7 @@ class GeneralOperationsRepository @Inject constructor(
         private const val PENDING_REAUTH_TENANT_NAME_KEY = "pending_reauth_tenant_name"
         private const val PENDING_REAUTH_PANEL_ID_KEY = "pending_reauth_panel_id"
         private const val PENDING_REAUTH_PANEL_NAME_KEY = "pending_reauth_panel_name"
+        private const val SESSION_STATE_PREFS = "session_state_prefs"
+        private const val SESSION_ACTIVE_KEY = "session_active"
     }
 }

--- a/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
+++ b/app/src/main/java/com/screenlake/data/repository/GeneralOperationsRepository.kt
@@ -280,19 +280,19 @@ class GeneralOperationsRepository @Inject constructor(
         return prefs.getInt(CREDENTIAL_FAILURE_COUNT_KEY, 0)
     }
 
-    fun markSessionActive() {
-        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(SESSION_ACTIVE_KEY, true).apply()
+    fun markAccessibilitySessionActive() {
+        val prefs = context.getSharedPreferences(ACCESSIBILITY_SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(ACCESSIBILITY_SESSION_ACTIVE_KEY, true).apply()
     }
 
-    fun markSessionInactive() {
-        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(SESSION_ACTIVE_KEY, false).apply()
+    fun markAccessibilitySessionInactive() {
+        val prefs = context.getSharedPreferences(ACCESSIBILITY_SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(ACCESSIBILITY_SESSION_ACTIVE_KEY, false).apply()
     }
 
-    fun isSessionActive(): Boolean {
-        val prefs = context.getSharedPreferences(SESSION_STATE_PREFS, Context.MODE_PRIVATE)
-        return prefs.getBoolean(SESSION_ACTIVE_KEY, false)
+    fun isAccessibilitySessionActive(): Boolean {
+        val prefs = context.getSharedPreferences(ACCESSIBILITY_SESSION_STATE_PREFS, Context.MODE_PRIVATE)
+        return prefs.getBoolean(ACCESSIBILITY_SESSION_ACTIVE_KEY, false)
     }
 
     /**
@@ -603,7 +603,7 @@ class GeneralOperationsRepository @Inject constructor(
         private const val PENDING_REAUTH_TENANT_NAME_KEY = "pending_reauth_tenant_name"
         private const val PENDING_REAUTH_PANEL_ID_KEY = "pending_reauth_panel_id"
         private const val PENDING_REAUTH_PANEL_NAME_KEY = "pending_reauth_panel_name"
-        private const val SESSION_STATE_PREFS = "session_state_prefs"
-        private const val SESSION_ACTIVE_KEY = "session_active"
+        private const val ACCESSIBILITY_SESSION_STATE_PREFS = "accessibility_session_state_prefs"
+        private const val ACCESSIBILITY_SESSION_ACTIVE_KEY = "accessibility_session_active"
     }
 }

--- a/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
@@ -81,7 +81,7 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
         sessionStart = true
         screenOff = false
         TouchAccessibilityService.isScreenOn.postValue(true)
-        generalOperationsRepository.markSessionActive()
+        generalOperationsRepository.markAccessibilitySessionActive()
 
         // Save the session start event in the database
         save("SESSION_START", startTime)
@@ -96,7 +96,7 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
         val endTime = Instant.now().toEpochMilli()
         save("SESSION_END", endTime)
         sessionStart = false
-        generalOperationsRepository.markSessionInactive()
+        generalOperationsRepository.markAccessibilitySessionInactive()
     }
 
     /**

--- a/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
@@ -81,6 +81,7 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
         sessionStart = true
         screenOff = false
         TouchAccessibilityService.isScreenOn.postValue(true)
+        generalOperationsRepository.markSessionActive()
 
         // Save the session start event in the database
         save("SESSION_START", startTime)
@@ -95,6 +96,7 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
         val endTime = Instant.now().toEpochMilli()
         save("SESSION_END", endTime)
         sessionStart = false
+        generalOperationsRepository.markSessionInactive()
     }
 
     /**

--- a/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/SystemAccessibilityEventReceiver.kt
@@ -50,6 +50,7 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
      */
     private fun handleScreenOff() {
         TouchAccessibilityService.isScreenOn.postValue(false)
+        generalOperationsRepository.markAccessibilitySessionInactive()
         if (sessionStart) {
             saveSessionEnd()
         }
@@ -96,7 +97,6 @@ class SystemAccessibilityEventReceiver(private val mContext: Context? = null) : 
         val endTime = Instant.now().toEpochMilli()
         save("SESSION_END", endTime)
         sessionStart = false
-        generalOperationsRepository.markAccessibilitySessionInactive()
     }
 
     /**

--- a/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositoryAccessibilitySessionActiveTest.kt
+++ b/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositoryAccessibilitySessionActiveTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class GeneralOperationsRepositorySessionActiveTest {
+class GeneralOperationsRepositoryAccessibilitySessionActiveTest {
 
     private fun buildRepository(): GeneralOperationsRepository {
         val context: Context = ApplicationProvider.getApplicationContext()
@@ -42,29 +42,29 @@ class GeneralOperationsRepositorySessionActiveTest {
     }
 
     @Test
-    fun `isSessionActive defaults to false when never set`() {
+    fun `isAccessibilitySessionActive defaults to false when never set`() {
         val repo = buildRepository()
 
-        assertFalse(repo.isSessionActive())
+        assertFalse(repo.isAccessibilitySessionActive())
     }
 
     @Test
-    fun `markSessionActive makes isSessionActive return true`() {
+    fun `markAccessibilitySessionActive makes isAccessibilitySessionActive return true`() {
         val repo = buildRepository()
 
-        repo.markSessionActive()
+        repo.markAccessibilitySessionActive()
 
-        assertTrue(repo.isSessionActive())
+        assertTrue(repo.isAccessibilitySessionActive())
     }
 
     @Test
-    fun `markSessionInactive makes isSessionActive return false`() {
+    fun `markAccessibilitySessionInactive makes isAccessibilitySessionActive return false`() {
         val repo = buildRepository()
-        repo.markSessionActive()
+        repo.markAccessibilitySessionActive()
 
-        repo.markSessionInactive()
+        repo.markAccessibilitySessionInactive()
 
-        assertFalse(repo.isSessionActive())
+        assertFalse(repo.isAccessibilitySessionActive())
     }
 
     @Test
@@ -84,7 +84,7 @@ class GeneralOperationsRepositorySessionActiveTest {
             uploadDailyDao = mockk<UploadDailyDao>(relaxed = true),
             restrictedAppDao = mockk<RestrictedAppDao>(relaxed = true),
         )
-        repo1.markSessionActive()
+        repo1.markAccessibilitySessionActive()
 
         val repo2 = GeneralOperationsRepository(
             context = context,
@@ -104,6 +104,6 @@ class GeneralOperationsRepositorySessionActiveTest {
         // Confirms the flag lives in SharedPreferences (survives a fresh repository
         // instance, e.g. a different process/object graph reading the same disk-backed
         // prefs file), not in an in-memory field on the repository object itself.
-        assertTrue(repo2.isSessionActive())
+        assertTrue(repo2.isAccessibilitySessionActive())
     }
 }

--- a/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositorySessionActiveTest.kt
+++ b/app/src/test/java/com/screenlake/data/repository/GeneralOperationsRepositorySessionActiveTest.kt
@@ -1,0 +1,109 @@
+package com.screenlake.data.repository
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.screenlake.data.database.dao.AccessibilityEventDao
+import com.screenlake.data.database.dao.AppSegmentDao
+import com.screenlake.data.database.dao.LogEventDao
+import com.screenlake.data.database.dao.PanelDao
+import com.screenlake.data.database.dao.RestrictedAppDao
+import com.screenlake.data.database.dao.ScreenshotDao
+import com.screenlake.data.database.dao.ScreenshotZipDao
+import com.screenlake.data.database.dao.SessionDao
+import com.screenlake.data.database.dao.UploadDailyDao
+import com.screenlake.data.database.dao.UploadHistoryDao
+import com.screenlake.data.database.dao.UserDao
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeneralOperationsRepositorySessionActiveTest {
+
+    private fun buildRepository(): GeneralOperationsRepository {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        return GeneralOperationsRepository(
+            context = context,
+            logEventDao = mockk<LogEventDao>(relaxed = true),
+            accessibilityEventDao = mockk<AccessibilityEventDao>(relaxed = true),
+            appSegmentDao = mockk<AppSegmentDao>(relaxed = true),
+            panelDao = mockk<PanelDao>(relaxed = true),
+            sessionDao = mockk<SessionDao>(relaxed = true),
+            screenshotDao = mockk<ScreenshotDao>(relaxed = true),
+            screenshotZipDao = mockk<ScreenshotZipDao>(relaxed = true),
+            userDao = mockk<UserDao>(relaxed = true),
+            uploadHistoryDao = mockk<UploadHistoryDao>(relaxed = true),
+            uploadDailyDao = mockk<UploadDailyDao>(relaxed = true),
+            restrictedAppDao = mockk<RestrictedAppDao>(relaxed = true),
+        )
+    }
+
+    @Test
+    fun `isSessionActive defaults to false when never set`() {
+        val repo = buildRepository()
+
+        assertFalse(repo.isSessionActive())
+    }
+
+    @Test
+    fun `markSessionActive makes isSessionActive return true`() {
+        val repo = buildRepository()
+
+        repo.markSessionActive()
+
+        assertTrue(repo.isSessionActive())
+    }
+
+    @Test
+    fun `markSessionInactive makes isSessionActive return false`() {
+        val repo = buildRepository()
+        repo.markSessionActive()
+
+        repo.markSessionInactive()
+
+        assertFalse(repo.isSessionActive())
+    }
+
+    @Test
+    fun `state persists across repository instances backed by the same context`() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val repo1 = GeneralOperationsRepository(
+            context = context,
+            logEventDao = mockk<LogEventDao>(relaxed = true),
+            accessibilityEventDao = mockk<AccessibilityEventDao>(relaxed = true),
+            appSegmentDao = mockk<AppSegmentDao>(relaxed = true),
+            panelDao = mockk<PanelDao>(relaxed = true),
+            sessionDao = mockk<SessionDao>(relaxed = true),
+            screenshotDao = mockk<ScreenshotDao>(relaxed = true),
+            screenshotZipDao = mockk<ScreenshotZipDao>(relaxed = true),
+            userDao = mockk<UserDao>(relaxed = true),
+            uploadHistoryDao = mockk<UploadHistoryDao>(relaxed = true),
+            uploadDailyDao = mockk<UploadDailyDao>(relaxed = true),
+            restrictedAppDao = mockk<RestrictedAppDao>(relaxed = true),
+        )
+        repo1.markSessionActive()
+
+        val repo2 = GeneralOperationsRepository(
+            context = context,
+            logEventDao = mockk<LogEventDao>(relaxed = true),
+            accessibilityEventDao = mockk<AccessibilityEventDao>(relaxed = true),
+            appSegmentDao = mockk<AppSegmentDao>(relaxed = true),
+            panelDao = mockk<PanelDao>(relaxed = true),
+            sessionDao = mockk<SessionDao>(relaxed = true),
+            screenshotDao = mockk<ScreenshotDao>(relaxed = true),
+            screenshotZipDao = mockk<ScreenshotZipDao>(relaxed = true),
+            userDao = mockk<UserDao>(relaxed = true),
+            uploadHistoryDao = mockk<UploadHistoryDao>(relaxed = true),
+            uploadDailyDao = mockk<UploadDailyDao>(relaxed = true),
+            restrictedAppDao = mockk<RestrictedAppDao>(relaxed = true),
+        )
+
+        // Confirms the flag lives in SharedPreferences (survives a fresh repository
+        // instance, e.g. a different process/object graph reading the same disk-backed
+        // prefs file), not in an in-memory field on the repository object itself.
+        assertTrue(repo2.isSessionActive())
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GeneralOperationsRepository.markAccessibilitySessionActive()`/`markAccessibilitySessionInactive()`/`isAccessibilitySessionActive()`, backed by a dedicated SharedPreferences file, following the existing credential-failure-count pattern.
- Wires `SystemAccessibilityEventReceiver`'s existing `saveSessionStart()`/`saveSessionEnd()` to update the new flag, alongside their unchanged existing behavior (in-memory fields, `accessibility_event` DB markers).
- Fixes a fail-open gap found during review: the flag is now cleared unconditionally on screen-off, independent of the `sessionStart` in-memory field that resets whenever the accessibility service reconnects (which previously could leave the flag stuck reporting "active" indefinitely).

This closes the pre-existing gap where "is a session active" could only be inferred from the `accessibility_event` table, which gets periodically emptied by the hourly upload/cleanup process — the actual signal a session-active check needs is now independent of that pipeline entirely.

## Test plan
- [x] Unit tests for the three new repository methods (default-false, active, inactive, cross-instance persistence) — `GeneralOperationsRepositoryAccessibilitySessionActiveTest`
- [x] Full `./gradlew testDebugUnitTest` suite green
- [x] `./gradlew assembleDebug` compiles clean
- [x] Follow-up: once AC-1150/AC-1212 (app install/uninstall tracking) is rebased, its session-only gating should be implemented to consume `isAccessibilitySessionActive()` so session active status is no longer lost after hourly upload.