### PR TITLE
AC-1043: Fix credential storage race and app-segment/upload gap causing tag-zero failures on new accounts

### DIFF
--- a/app/src/main/java/com/screenlake/recorder/services/ScreenshotService.kt
+++ b/app/src/main/java/com/screenlake/recorder/services/ScreenshotService.kt
@@ -998,7 +998,8 @@ class ScreenshotService : Service(), ScreenStateReceiver.ScreenStateCallback {
         isScreenLocked.set(true)
 
         CoroutineScope(Dispatchers.IO).launch {
-            saveSessionSegmentsInBackground()
+            // Segment-building now happens inside beginOcr() (called below), which covers
+            // this path too -- no need to duplicate it here.
             generalOperationsRepository.buildCurrentSession(framesPerSecondConst, "SCREEN_OFF")
             generalOperationsRepository.saveSession(generalOperationsRepository.currentSession)
             // Create a new session.
@@ -1046,6 +1047,12 @@ class ScreenshotService : Service(), ScreenStateReceiver.ScreenStateCallback {
     }
 
     private fun beginOcr() = CoroutineScope(Dispatchers.IO).launch {
+        // Screenshots only become zip-eligible once they belong to an app segment (see
+        // ScreenshotDao's batch queries). The manual-upload trigger (button2 -> uploadCommand())
+        // calls straight into this function without going through a session-ending event first,
+        // so segments must be built here rather than assumed to already exist.
+        generalOperationsRepository.saveAllSessionSegments()
+
         val screenshots = generalOperationsRepository.getScreenshotsToOcr(1000)
         Timber.tag(TAG).d("Starting OCR: Processing ${screenshots.size} images.")
         processedCount = 0

--- a/app/src/main/java/com/screenlake/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/screenlake/ui/fragments/SettingsFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.preference.PreferenceManager
 import android.view.View
 import androidx.activity.OnBackPressedCallback
-import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -29,8 +28,6 @@ import kotlin.collections.get
 
 @AndroidEntryPoint
 class SettingsFragment : PreferenceFragmentCompat() {
-    // Create an extension property for DataStore
-    private val Context.dataStore by preferencesDataStore(name = "settings")
 
     @Inject
     lateinit var generalOperationsRepository: GeneralOperationsRepository


### PR DESCRIPTION
## Summary

Follow-up to #18. A user testing v1.50.1 still hit the same "Protocol message contained an invalid tag (zero)" error on a fresh account, so this branch digs further and fixes two additional bugs found in this new investigation, alongside re-verifying the original fix.

- **DataStore duplicate-instance bug**: `SettingsFragment.kt` and `SharedPreferencesUtil.kt` each independently declared their own `Context.dataStore` delegate for the same `"settings"` file. AndroidX DataStore Preferences serializes via its own vendored protobuf copy (`androidx.datastore.preferences.protobuf`), which throws an `InvalidProtocolBufferException` with the exact same message text as the Tink/EncryptedSharedPreferences error #18 already fixed -- meaning that fix alone didn't cover every source of this error. `SettingsFragment`'s declaration was unused dead code; removed it so there's exactly one DataStore instance for this file.

- **App segments never built for manually-triggered uploads**: while re-verifying on-device, found that `ZipFileWorker`'s batch queries only pick up screenshots that already belong to an app segment, but segment-building only ran from session-ending events (screen-off, service stop/destroy, projection revoked). The manual "Upload" button bypasses all of those and calls straight into `beginOcr()`, so screenshots it processed could never pass the zip-eligibility check -- only the segment-independent log CSV ever uploaded, making it look like uploads worked when real screenshot data silently never did. `beginOcr()` now builds segments itself first, covering every trigger path; removed the now-redundant call from the one call site that already leads into `beginOcr()` afterward.

## Test plan

- [x] Full unit test suite passes (`./gradlew testDebugUnitTest`).
- [x] Verified on a physical device with app data fully cleared (genuine first-ever Keystore/keyset/DataStore creation): registered a brand-new account, confirmed real credential round-trip, and confirmed the full OCR -> segment -> zip -> upload pipeline completed successfully with no crash and no recurrence of the tag-zero error.
- [x] Verified the manual upload button separately: previously produced "Found 0 zips to upload" indefinitely; now correctly builds segments and uploads real screenshot/CSV zips.