### PR TITLE
AC-1202: Enable GitHub Advanced Security and prepare 1.51.0 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.screenlake"
         minSdk = 28
         targetSdk = 35
-        versionCode = 51
-        versionName = "1.50.0"
+        versionCode = 52
+        versionName = "1.51.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -57,8 +57,8 @@ android {
 
     buildTypes {
         release {
-//            isMinifyEnabled = true
-//            isDebuggable = false
+            isMinifyEnabled = true
+            isDebuggable = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.google.services)
-    alias(libs.plugins.google.secrets)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.kotlin.android)
     id("kotlin-kapt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.devtools.ksp) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
-    alias(libs.plugins.google.secrets) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.kotlin.android) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,6 @@ okHttpBom = "5.3.2"
 retrofit = "3.0.0"
 robolectric = "4.16.1"
 room = "2.8.4"
-secrets = "2.0.1"
 tesseract4Android = "4.9.0"
 timber = "4.7.1"
 truth = "1.4.5"
@@ -115,7 +114,6 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 android-application = { id = "com.android.application", version.ref = "android" }
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtoolsKsp" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
-google-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Removes the unused `secrets-gradle-plugin`, which threw `FileNotFoundException` whenever `local.properties` was absent, blocking CodeQL's Autobuild step in CI. Nothing in the app consumes its `${}` placeholder injection; AWS/Cognito values are already read manually with safe defaults in `app/build.gradle.kts`.
- Bumps `versionCode`/`versionName` to `52`/`1.51.0` and restores `isMinifyEnabled`/`isDebuggable` in the release build type ahead of the 1.51.0 release.

## Test plan
- [x] `./gradlew :app:help` succeeds with `local.properties` absent (previously failed here)
- [x] `./gradlew :app:compileDebugKotlin` compiles successfully without `local.properties`