### PR TITLE
Add issue template chooser and Ideas discussion form

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,3 +1,4 @@
+# Filename must match the "Ideas" discussion category's slug ("ideas") exactly, or GitHub will not attach this form to the category.
 title: "[Idea]: "
 body:
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,20 @@
+title: "[Idea]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What issue does this new feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: What is the proposed solution?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What alternative solutions have you considered?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -22,6 +22,8 @@ body:
       label: Expected behavior
     validations:
       required: false
+  # Intentionally not a list of literal version numbers, which would go stale every release.
+  # Mirrors SECURITY.md's "only the latest release is supported" policy.
   - type: dropdown
     id: app-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -24,22 +24,13 @@ body:
       required: false
   # Intentionally not a list of literal version numbers, which would go stale every release.
   # Mirrors SECURITY.md's "only the latest release is supported" policy.
-  - type: dropdown
+  - type: input
     id: app-version
     attributes:
-      label: App version
-      options:
-        - Latest release
-        - Previous version (specify below)
-    validations:
-      required: true
-  - type: input
-    id: previous-version
-    attributes:
-      label: If "Previous version," which one?
+      label: Affected app version?
       placeholder: e.g. 1.50.1
     validations:
-      required: false
+      required: true
   - type: textarea
     id: affected-devices
     attributes:
@@ -50,13 +41,13 @@ body:
   - type: dropdown
     id: reporter-role
     attributes:
-      label: Are you a researcher/developer or a study participant?
+      label: Are you a researcher, developer or a study participant?
       options:
-        - Researcher/developer
+        - Researcher
+        - Developer
         - Study participant
-        - Not sure
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: Report a problem with the SMART app or its setup/build tooling
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+    validations:
+      required: false
+  - type: dropdown
+    id: app-version
+    attributes:
+      label: App version
+      options:
+        - Latest release
+        - Previous version (specify below)
+    validations:
+      required: true
+  - type: input
+    id: previous-version
+    attributes:
+      label: If "Previous version," which one?
+      placeholder: e.g. 1.50.1
+    validations:
+      required: false
+  - type: textarea
+    id: affected-devices
+    attributes:
+      label: Affected device(s) and Android version(s)
+      placeholder: "Pixel 7, Android 14; Galaxy S21, Android 13"
+    validations:
+      required: true
+  - type: dropdown
+    id: reporter-role
+    attributes:
+      label: Are you a researcher/developer or a study participant?
+      options:
+        - Researcher/developer
+        - Study participant
+        - Not sure
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Do not attach real participant screen-capture data. It may contain sensitive information this app exists to protect.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/2-documentation-issue.yml
@@ -1,0 +1,30 @@
+name: Documentation Issue
+description: Report something wrong, unclear, or missing in the README, Quickstart, Participant Guide, or other docs
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: dropdown
+    id: which-doc
+    attributes:
+      label: Which doc?
+      options:
+        - README.md
+        - QUICKSTART.md
+        - PARTICIPANT_GUIDE.md
+        - SECURITY.md
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: What's wrong or unclear?
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/researchaccelerator-hub/princeton-smart/discussions/categories/ideas
+    about: Suggest a new feature or capability for SMART
+  - name: Report a Security Vulnerability
+    url: https://github.com/researchaccelerator-hub/princeton-smart/blob/main/SECURITY.md
+    about: Do not report vulnerabilities as public issues, see our security policy for how to report privately
+  - name: Questions / General Discussion
+    url: https://github.com/researchaccelerator-hub/princeton-smart/discussions
+    about: Ask a question or start a general discussion


### PR DESCRIPTION
## Summary
- Adds a 5-option issue chooser: Bug Report and Documentation Issue open structured issue forms; Feature Request, Report a Security Vulnerability, and Questions/General Discussion redirect to Discussions/SECURITY.md. Blank issues are disabled.
- Adds a structured discussion form for the Ideas category, reached both directly and via the Feature Request redirect.
- Inline YAML comments document two non-obvious constraints: the Ideas form's filename must match the category slug exactly, and the Bug Report's "App version" dropdown is intentionally not a maintained list of literal version numbers (mirrors SECURITY.md's latest-release-only support policy).