### PR TITLE
Fix AC-1252: Zip Slip vulnerability in ZipFile unzip extraction

### DIFF
--- a/app/src/main/java/com/screenlake/recorder/utilities/ZipFile.kt
+++ b/app/src/main/java/com/screenlake/recorder/utilities/ZipFile.kt
@@ -66,6 +66,7 @@ class ZipFile {
             if (!it.endsWith(File.separator)) "$it${File.separator}"
             else it
         }
+        val locationCanonicalPath = location.canonicalPath
 
         var zipEntry: ZipEntry?
         var unzipFile: File
@@ -73,6 +74,14 @@ class ZipFile {
 
         while (inStream.nextEntry.also { zipEntry = it } != null) {
             unzipFile = File(locationPath + zipEntry!!.name)
+
+            val entryCanonicalPath = unzipFile.canonicalPath
+            if (entryCanonicalPath != locationCanonicalPath &&
+                !entryCanonicalPath.startsWith(locationCanonicalPath + File.separator)
+            ) {
+                throw SecurityException("Zip entry is outside of the target directory: ${zipEntry!!.name}")
+            }
+
             if (zipEntry!!.isDirectory) {
                 if (!unzipFile.isDirectory) unzipFile.mkdirs()
             } else {


### PR DESCRIPTION
## Summary
- Validate each archive entry's canonical path against the target extraction directory in `ZipFile.unzip()` before writing, closing the arbitrary file write path flagged by CodeQL as a Zip Slip vulnerability (java/zipslip).
- Throws `SecurityException` if a crafted entry (e.g. containing `../`) would resolve outside the intended extraction directory.

The three related "implicit PendingIntent" CodeQL alerts (java/android/implicit-pendingintents) were reviewed and dismissed as false positives; the underlying intent already uses an explicit component and `FLAG_IMMUTABLE`, but CodeQL's Kotlin dataflow modeling loses that through the `.apply { }` scope function.